### PR TITLE
replace_text_in_files: Clarify that this should only target .txt files

### DIFF
--- a/challenges.yaml
+++ b/challenges.yaml
@@ -237,9 +237,9 @@
     disp_title: Replace text in files
     example: find . -name "*.txt" -exec sed -i -e 's/challenges are difficult//g' "{}" \;
     description: |
-      This challenge has text files that contain
-      the phrase "challenges are difficult". Delete
-      this phrase recursively from all text files.
+      This challenge has text files (with a .txt extension)
+      that contain the phrase "challenges are difficult".
+      Delete this phrase recursively from all text files.
     tests:
       - test: '[[ $(find . -name "*.txt" | wc -l) == 3 ]]'
         msg: Test failed, expecting 3 text files

--- a/var/challenges/replace_text_in_files/README
+++ b/var/challenges/replace_text_in_files/README
@@ -1,7 +1,7 @@
 # Replace Text In Files
 # *********************
 
-# This challenge has text files that contain
-# the phrase "challenges are difficult". Delete
-# this phrase recursively from all text files.
+# This challenge has text files (with a .txt extension)
+# that contain the phrase "challenges are difficult".
+# Delete this phrase recursively from all text files.
 # 


### PR DESCRIPTION
Without the mention of the ".txt" extension, people could reasonably
assume that the command needs to process any text file.