### PR TITLE
Small grammatical typo and new test for remove_extensions_from_files

### DIFF
--- a/challenges.yaml
+++ b/challenges.yaml
@@ -376,6 +376,8 @@
     tests:
       - test: '[[ $(find . -type f -name "*.*") == "" ]]'
         msg: Test failed, there are still files with extensions in the current directory.
+      - test: '[[ $(find . -type f | wc -l) == 9 ]]'
+        msg: Test failed, expecting 9 files.
   - slug: replace_spaces_in_filenames
     version: 2
     author: cmdchallenge

--- a/challenges.yaml
+++ b/challenges.yaml
@@ -340,7 +340,7 @@
     disp_title: Sum numbers in a file.
     example: paste -sd+ sum-me.txt  | bc
     description: |
-      The file sum-me.txt have a list of numbers,
+      The file sum-me.txt has a list of numbers,
       one per line. Print the sum of these numbers.
     expected_output:
       lines:


### PR DESCRIPTION
The new test prohibits users from simply deleting all the files to pass remove_extensions_from_files. This happened while I was going through your challenges, so I figured I'd contribute a quick fix.

Hope it helps!

Cheers