### PR TITLE
Use 'find -L . -type -f | wc -l' rather than 'ls | wc -l' to count files

### DIFF
--- a/challenges.yaml
+++ b/challenges.yaml
@@ -192,12 +192,12 @@
       Count the number of files in the current
       working directory. Print the number of
       files as a single integer.
-    example: ls | wc -l
-    example_fail: echo 2
+    example: find -L . -type f | wc -l
+    example_fail: ls | wc -l
     expected_output:
       re_sub: ['^\s+', '']
       lines:
-        - '2'
+        - '3'
   - slug: simple_sort
     version: 4
     author: cmdchallenge

--- a/challenges.yaml
+++ b/challenges.yaml
@@ -186,14 +186,14 @@
       their contents.
     example: find . -delete
   - slug: count_files
-    version: 5
+    version: 6
     author: cmdchallenge
     description: |
       Count the number of files in the current
       working directory. Print the number of
       files as a single integer.
     example: find -L . -type f | wc -l
-    example_fail: ls | wc -l
+    example_fail: echo 3
     expected_output:
       re_sub: ['^\s+', '']
       lines:

--- a/ro_volume/randomizers/count_files
+++ b/ro_volume/randomizers/count_files
@@ -2,5 +2,5 @@
 for i in $(seq 0 $(( $RANDOM % 20 ))); do
     touch $i
 done
-ls | wc -l
+find -L . -type f | wc -l
 exit 0

--- a/var/challenges/count_files/.hidden
+++ b/var/challenges/count_files/.hidden
@@ -1,0 +1,1 @@
+../../common/.hidden

--- a/var/common/.hidden
+++ b/var/common/.hidden
@@ -1,0 +1,1 @@
+Some text in a hidden file


### PR DESCRIPTION
Fixes https://github.com/jarv/cmdchallenge/issues/21